### PR TITLE
Jotai 추가 및 버그 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@react-three/drei": "^9.114.0",
         "@react-three/fiber": "^8.17.8",
         "firebase": "^10.13.2",
+        "jotai": "^2.10.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -4039,6 +4040,27 @@
       "integrity": "sha512-SN9c4kxXZonFhbX4hJrZy37yw9e7EIxcpHCxQv5JUS18wDE5ovkQKlqQEkufdJCCMfuI9BnjUJvhYeJ9x5Ra7g==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/jotai": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/jotai/-/jotai-2.10.0.tgz",
+      "integrity": "sha512-8W4u0aRlOIwGlLQ0sqfl/c6+eExl5D8lZgAUolirZLktyaj4WnxO/8a0HEPmtriQAB6X5LMhXzZVmw02X0P0qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=17.0.0",
+        "react": ">=17.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
       }
     },
     "node_modules/js-tokens": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@react-three/drei": "^9.114.0",
     "@react-three/fiber": "^8.17.8",
     "firebase": "^10.13.2",
+    "jotai": "^2.10.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/atoms/index.js
+++ b/src/atoms/index.js
@@ -1,0 +1,3 @@
+import { paperAtom } from './paperAtom';
+
+export { paperAtom };

--- a/src/atoms/paperAtom.js
+++ b/src/atoms/paperAtom.js
@@ -1,0 +1,13 @@
+import { atom } from 'jotai';
+import { PAPERCOLORS } from '../constants/paper';
+import { getRandomIndex } from '../utils/getRandomIndex';
+
+export const paperAtom = atom(() => {
+  const [frontColorIndex, backColorIndex] = getRandomIndex(
+    PAPERCOLORS.length - 1
+  );
+  return {
+    frontColor: PAPERCOLORS[frontColorIndex],
+    backColor: PAPERCOLORS[backColorIndex],
+  };
+});

--- a/src/components/Paper.jsx
+++ b/src/components/Paper.jsx
@@ -1,22 +1,18 @@
 import * as THREE from 'three';
 import PaperShaderMaterial from '../three/PaperShaderMaterial';
-
-import { getRandomIndex } from '../utils/getRandomIndex';
-import { PAPERCOLORS, SEGMENT_NUM } from '../constants/paper';
+import { useAtom } from 'jotai';
+import { paperAtom } from '../atoms';
+import { SEGMENT_NUM } from '../constants/paper';
 
 const Paper = props => {
-  const [frontColorIndex, backColorIndex] = getRandomIndex(
-    PAPERCOLORS.length - 1
-  );
-  const frontColor = PAPERCOLORS[frontColorIndex];
-  const backColor = PAPERCOLORS[backColorIndex];
+  const [colors] = useAtom(paperAtom);
 
   return (
     <mesh {...props}>
       <planeGeometry args={[3, 3, SEGMENT_NUM, SEGMENT_NUM]} />
       <paperShaderMaterial
-        colorFront={new THREE.Color(frontColor)}
-        colorBack={new THREE.Color(backColor)}
+        colorFront={new THREE.Color(colors.frontColor)}
+        colorBack={new THREE.Color(colors.backColor)}
         side={THREE.DoubleSide}
         wireframe={false}
       />


### PR DESCRIPTION
# jotai 추가
![image](https://github.com/user-attachments/assets/f769038e-24eb-4ba8-990a-8444391fa0cf)
Jotai를 추가하면서 atoms 폴더 생성했습니다.

index.js는 Atom들을 한번에 모아서 export하는 파일입니다. 
성격에 따라서 추가적인 atom 파일을 나눠서 생성하면 가독성이 좋아질 것 같아 나누었습니다.

# 색상 바뀌는 버그 수정
재렌더링되어도 paper의 색상이 변경되지 않게 수정했습니다.

**컴포넌트 내부 상태**로 색상을 관리했기 때문에 이전에는
Paper 컴포넌트는 매번 렌더링될 때마다 getRandomIndex 함수를 호출하여 frontColor와 backColor를 재설정하고 있었습니다. 이로 인해 리렌더링이 발생할 때마다 색상이 계속 변경되는 문제가 발생했습니다.

부모 컴포넌트가 리렌더링될 때: 부모 컴포넌트의 상태 변화나 리렌더링으로 인해 자식 컴포넌트인 Paper도 리렌더링됩니다.
props가 변경될 때: Paper 컴포넌트에 전달된 props가 변경될 때마다 리렌더링이 발생합니다.

### 해결
Jotai의 atom을 사용하여 색상 상태를 전역 상태로 관리함으로써, 색상이 컴포넌트의 리렌더링과 무관하게 유지됩니다. Jotai를 사용하면 컴포넌트의 상태가 전역으로 관리되어 리렌더링이 발생해도 초기화되지 않고 유지됩니다.


![렌더링버그](https://github.com/user-attachments/assets/bc097033-8d01-441e-9c88-0d5a3591c0ee)
![렌더링버그해결](https://github.com/user-attachments/assets/0267a995-6ca6-442f-b57c-7e92b678ea01)
