### PR TITLE
🐛 Fix: 캔버스 크기 조정 및 z-index 조정

### DIFF
--- a/src/GuideSlide.jsx
+++ b/src/GuideSlide.jsx
@@ -33,6 +33,7 @@ const GuideWrap = styled.div`
   position: absolute;
   top: 39px;
   left: 57px;
+  z-index: 20;
   padding: 16px 60px;
   border-radius: 30px;
   background-color: rgba(255, 255, 255, 0.5);

--- a/src/Play.jsx
+++ b/src/Play.jsx
@@ -95,6 +95,7 @@ const PlayGuide = styled.div`
   position: absolute;
   top: 39px;
   right: 57px;
+  z-index: 20;
   padding: 16px 20px;
   border-radius: 10px;
   background-color: rgba(255, 255, 255, 0.5);
@@ -144,8 +145,8 @@ const Play = () => {
 
   return (
     <MainContainer>
-      <CanvasComp />
       <SectionContainer>
+        <CanvasComp />
         {mode && <GuideSlide />}
         <PlayGuide>
           <PlayGuideP>

--- a/src/components/CanvasComp.jsx
+++ b/src/components/CanvasComp.jsx
@@ -7,8 +7,8 @@ import Paper from './Paper';
 
 const CanvasContainer = styled.div`
   position: absolute;
-  width: 100vw;
-  height: 100vh;
+  width: 100%;
+  height: 100%;
   z-index: 1;
 `;
 


### PR DESCRIPTION


# canvas 크기 조정

<img width="500" alt="image" src="https://github.com/user-attachments/assets/d13db1aa-19f3-47cb-b2a9-b195a02081d2">

캔버스가 play화면보다 더 크게 설정되어 종이가 밖으로 나가는 현상 수정

# 3D 종이가 툴팁 및 가이드 가려짐 현상 수정

<img width="400" alt="image" src="https://github.com/user-attachments/assets/9666b696-a82a-42f9-8c8d-5c147d30481f">
<img width="400" alt="image" src="https://github.com/user-attachments/assets/9de6dd67-7bd8-43e9-b67f-63652bdd16f2">

종이가 커졌을 때, GuideSlide 및 툴팁 가려짐 현상 수정